### PR TITLE
ND-13704 switch Config recorder to SLR; split SSM remediation role

### DIFF
--- a/config-rules.tf
+++ b/config-rules.tf
@@ -237,7 +237,7 @@ resource "aws_config_remediation_configuration" "s3-bucket-server-side-encryptio
 
   parameter {
     name         = "AutomationAssumeRole"
-    static_value = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-config-role-${var.region}"
+    static_value = aws_iam_role.remediation.0.arn
   }
   parameter {
     name           = "BucketName"
@@ -289,7 +289,7 @@ resource "aws_config_remediation_configuration" "s3-bucket-versioning-enabled" {
 
   parameter {
     name         = "AutomationAssumeRole"
-    static_value = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-config-role-${var.region}"
+    static_value = aws_iam_role.remediation.0.arn
   }
   parameter {
     name           = "BucketName"
@@ -335,7 +335,7 @@ resource "aws_config_remediation_configuration" "s3-bucket-ssl-requests-only" {
 
   parameter {
     name         = "AutomationAssumeRole"
-    static_value = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-config-role-${var.region}"
+    static_value = aws_iam_role.remediation.0.arn
   }
   parameter {
     name           = "BucketName"

--- a/config-service.tf
+++ b/config-service.tf
@@ -3,14 +3,14 @@
 #
 
 resource "aws_config_configuration_recorder_status" "main" {
-  count = var.active == true ? 1 : 0
+  count      = var.active == true ? 1 : 0
   name       = "aws-config-${var.region}"
   is_enabled = true
   depends_on = [aws_config_delivery_channel.main]
 }
 
 resource "aws_config_delivery_channel" "main" {
-  count = var.active == true ? 1 : 0
+  count          = var.active == true ? 1 : 0
   name           = "aws-config-${var.region}"
   s3_bucket_name = var.config_logs_bucket
   s3_key_prefix  = var.config_logs_prefix
@@ -23,9 +23,9 @@ resource "aws_config_delivery_channel" "main" {
 }
 
 resource "aws_config_configuration_recorder" "main" {
-  count = var.active == true ? 1 : 0
+  count    = var.active == true ? 1 : 0
   name     = "aws-config-${var.region}"
-  role_arn = aws_iam_role.main.0.arn
+  role_arn = var.config_role_arn
 
   recording_group {
     all_supported                 = true

--- a/iam.tf
+++ b/iam.tf
@@ -1,9 +1,10 @@
-# Get the access to the effective Account ID in which Terraform is working.
 data "aws_caller_identity" "current" {
 }
 
-# Allows AWS Config IAM role to access the S3 bucket where AWS Config records
-# are stored.
+# IAM policy doc attached to the SSM remediation role. Grants the S3
+# put/lifecycle/tagging actions that the Config rule remediations
+# (s3-lifecycle, s3-tags, bucket policy enforcement) execute via SSM
+# Automation. Unchanged from the legacy aws-config-role template.
 data "template_file" "aws_config_policy" {
   template = file("${path.module}/iam-policies/aws-config-policy.tpl")
 
@@ -14,51 +15,32 @@ data "template_file" "aws_config_policy" {
   }
 }
 
-# Allow IAM policy to assume the role for AWS Config
-data "aws_iam_policy_document" "aws-config-role-policy" {
+data "aws_iam_policy_document" "remediation-trust" {
   statement {
     actions = ["sts:AssumeRole"]
-
     principals {
       type        = "Service"
-      identifiers = ["config.amazonaws.com", "ssm.amazonaws.com"]
+      identifiers = ["ssm.amazonaws.com"]
     }
-
     effect = "Allow"
   }
 }
 
-#
-# IAM
-#
-
-resource "aws_iam_role" "main" {
-  count = var.active == true ? 1 : 0
-  name  = "aws-config-role-${var.region}"
-
-  assume_role_policy = data.aws_iam_policy_document.aws-config-role-policy.json
+resource "aws_iam_role" "remediation" {
+  count              = var.active == true ? 1 : 0
+  name               = "aws-config-remediation-role-${var.region}"
+  assume_role_policy = data.aws_iam_policy_document.remediation-trust.json
 }
 
-resource "aws_iam_policy_attachment" "managed-policy" {
-  count      = var.active == true ? 1 : 0
-  name       = "aws-config-managed-policy-${var.region}"
-  roles      = [aws_iam_role.main.0.name]
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
-  lifecycle {
-    ignore_changes = ["roles"] # multiregional hack
-  }
-}
-
-resource "aws_iam_policy" "aws-config-policy" {
+resource "aws_iam_policy" "remediation" {
   count  = var.active == true ? 1 : 0
-  name   = "aws-config-policy-${var.region}"
+  name   = "aws-config-remediation-policy-${var.region}"
   policy = data.template_file.aws_config_policy.rendered
 }
 
-resource "aws_iam_policy_attachment" "aws-config-policy" {
+resource "aws_iam_policy_attachment" "remediation" {
   count      = var.active == true ? 1 : 0
-  name       = "aws-config-policy-${var.region}"
-  roles      = [aws_iam_role.main.0.name]
-  policy_arn = aws_iam_policy.aws-config-policy.0.arn
+  name       = "aws-config-remediation-policy-${var.region}"
+  roles      = [aws_iam_role.remediation.0.name]
+  policy_arn = aws_iam_policy.remediation.0.arn
 }
-

--- a/s3-lifecycle.tf
+++ b/s3-lifecycle.tf
@@ -2,6 +2,7 @@ resource "aws_ssm_document" "s3_lifecycle" {
   name            = "ConfigureS3BucketLifecycleRule"
   document_type   = "Automation"
   document_format = "YAML"
+  version_name    = "2.0.11"
 
   content = templatefile("${path.module}/automations/ConfigureS3BucketLifecycleRule.yaml", {})
 

--- a/s3-lifecycle.tf
+++ b/s3-lifecycle.tf
@@ -29,11 +29,11 @@ resource "aws_config_remediation_configuration" "s3-bucket-expiration" {
   resource_type    = "AWS::S3::Bucket"
   target_type      = "SSM_DOCUMENT"
   target_id        = aws_ssm_document.s3_lifecycle.name
-  target_version = "$DEFAULT"
+  target_version   = "$DEFAULT"
 
   parameter {
     name         = "AutomationAssumeRole"
-    static_value = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-config-role-${var.region}"
+    static_value = aws_iam_role.remediation.0.arn
   }
   parameter {
     name           = "BucketName"

--- a/s3-tags.tf
+++ b/s3-tags.tf
@@ -21,9 +21,9 @@ resource "aws_config_config_rule" "s3-bucket-tags" {
   scope {
     compliance_resource_types = ["AWS::S3::Bucket"]
   }
-  
-  
-  input_parameters= <<EOF
+
+
+  input_parameters = <<EOF
 {
 	"tag1Key": "cost"
 }
@@ -33,22 +33,22 @@ EOF
 }
 
 resource "aws_config_remediation_configuration" "s3-bucket-tags" {
-  count            = var.active == true  ? 1 : 0 # && var.region != "ap-northeast-3" ? 1 : 0
+  count            = var.active == true ? 1 : 0 # && var.region != "ap-northeast-3" ? 1 : 0
   config_rule_name = aws_config_config_rule.s3-bucket-tags[0].name
   resource_type    = "AWS::S3::Bucket"
   target_type      = "SSM_DOCUMENT"
   target_id        = aws_ssm_document.s3_tags.name
-  target_version = "$DEFAULT"
+  target_version   = "$DEFAULT"
 
   parameter {
     name         = "AutomationAssumeRole"
-    static_value = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-config-role-${var.region}"
+    static_value = aws_iam_role.remediation.0.arn
   }
   parameter {
     name           = "BucketName"
     resource_value = "RESOURCE_ID"
   }
-  
+
   automatic                  = true
   maximum_automatic_attempts = 5
   retry_attempt_seconds      = 600

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,8 @@ variable "active" {
   default = true
 }
 
+variable "config_role_arn" {
+  description = "ARN of the IAM role the Config recorder assumes. Expected: the AWSServiceRoleForConfig SLR, provisioned once per account by the parent module."
+  type        = string
+}
+


### PR DESCRIPTION
## Summary

- Drop custom recorder IAM role `aws-config-role-${region}`; consumer now passes `config_role_arn` (expected: `AWSServiceRoleForConfig` service-linked role) via new required var.
- Split SSM automation remediations onto dedicated role `aws-config-remediation-role-${region}` (trust: `ssm.amazonaws.com` only). Config rule remediations in `config-rules.tf` / `s3-lifecycle.tf` / `s3-tags.tf` now reference `aws_iam_role.remediation.0.arn`.
- Fixes Security Hub control **Config.1** (`ReasonCode: CONFIG_RECORDER_CUSTOM_ROLE`) org-wide.

**Breaking** — new required variable. Cut as tag `3.0.0`. Parent `fn_terraform/modules/config/main.tf` bumps `?ref=2.0.12` → `?ref=3.0.0` in a paired PR (ND-13704).

## Jira
https://fraudnet.atlassian.net/browse/ND-13704

## Test plan
- [ ] `terraform fmt -check` clean on touched files
- [ ] Dry-run canary: `fn_terraform` `master-ds-pov/config` `terragrunt plan` shows SLR import + `role_arn` swap on every recorder + custom role destroy + remediation role create + 5 SSM targets repointed
- [ ] Dev apply → wait 30 min → `securityhub get-findings` Config.1 flips to PASSED
- [ ] Roll out: `cloudtrail` → `master` → `sso-entry` → `aws-seller` → `global`