### PR TITLE
ND-13704 drop hashicorp/template provider (darwin_arm64 fix)

### DIFF
--- a/config-rules.tf
+++ b/config-rules.tf
@@ -1,8 +1,6 @@
-data "template_file" "aws_config_iam_password_policy" {
-  template = file("${path.module}/config-policies/iam-password-policy.tpl")
-
-  vars = {
-    # terraform will interpolate boolean as 0/1 and the config parameters expect "true" or "false"
+locals {
+  aws_config_iam_password_policy = templatefile("${path.module}/config-policies/iam-password-policy.tpl", {
+    # terraform interpolates booleans as 0/1; AWS Config expects "true" / "false"
     password_require_uppercase = var.password_require_uppercase ? "true" : "false"
     password_require_lowercase = var.password_require_lowercase ? "true" : "false"
     password_require_symbols   = var.password_require_symbols ? "true" : "false"
@@ -10,17 +8,11 @@ data "template_file" "aws_config_iam_password_policy" {
     password_min_length        = var.password_min_length
     password_reuse_prevention  = var.password_reuse_prevention
     password_max_age           = var.password_max_age
-  }
-}
+  })
 
-data "template_file" "aws_config_acm_certificate_expiration" {
-  template = file(
-    "${path.module}/config-policies/acm-certificate-expiration.tpl",
-  )
-
-  vars = {
+  aws_config_acm_certificate_expiration = templatefile("${path.module}/config-policies/acm-certificate-expiration.tpl", {
     acm_days_to_expiration = var.acm_days_to_expiration
-  }
+  })
 }
 
 #
@@ -31,7 +23,7 @@ resource "aws_config_config_rule" "iam-password-policy" {
   count            = var.active == true ? 1 : 0
   name             = "iam-password-policy"
   description      = "Ensure the account password policy for IAM users meets the specified requirements"
-  input_parameters = data.template_file.aws_config_iam_password_policy.rendered
+  input_parameters = local.aws_config_iam_password_policy
 
   source {
     owner             = "AWS"
@@ -102,7 +94,7 @@ resource "aws_config_config_rule" "acm-certificate-expiration-check" {
   count            = var.active == true && var.region != "ap-northeast-3" ? 1 : 0
   name             = "acm-certificate-expiration-check"
   description      = "Ensures ACM Certificates in your account are marked for expiration within the specified number of days"
-  input_parameters = data.template_file.aws_config_acm_certificate_expiration.rendered
+  input_parameters = local.aws_config_acm_certificate_expiration
 
   source {
     owner             = "AWS"

--- a/iam.tf
+++ b/iam.tf
@@ -5,14 +5,12 @@ data "aws_caller_identity" "current" {
 # put/lifecycle/tagging actions that the Config rule remediations
 # (s3-lifecycle, s3-tags, bucket policy enforcement) execute via SSM
 # Automation. Unchanged from the legacy aws-config-role template.
-data "template_file" "aws_config_policy" {
-  template = file("${path.module}/iam-policies/aws-config-policy.tpl")
-
-  vars = {
+locals {
+  aws_config_policy = templatefile("${path.module}/iam-policies/aws-config-policy.tpl", {
     config_logs_bucket = var.config_logs_bucket
     config_logs_prefix = var.config_logs_prefix
     account_id         = data.aws_caller_identity.current.account_id
-  }
+  })
 }
 
 data "aws_iam_policy_document" "remediation-trust" {
@@ -35,7 +33,7 @@ resource "aws_iam_role" "remediation" {
 resource "aws_iam_policy" "remediation" {
   count  = var.active == true ? 1 : 0
   name   = "aws-config-remediation-policy-${var.region}"
-  policy = data.template_file.aws_config_policy.rendered
+  policy = local.aws_config_policy
 }
 
 resource "aws_iam_policy_attachment" "remediation" {


### PR DESCRIPTION
## Summary

- Replace `data "template_file"` (3 instances across `iam.tf` + `config-rules.tf`) with the `templatefile()` builtin + `locals`.
- `hashicorp/template` v2.2.0 has no `darwin_arm64` package — broke `terragrunt init` on M-series Macs during ND-13704 canary plan.
- Same `.tpl` files, identical rendered output. No runtime change.

Follow-up tag: `v.3.0.1` (or squash into `v.3.0.0` re-cut).

## Jira
https://fraudnet.atlassian.net/browse/ND-13704