### PR TITLE
Remove static version_name from s3_lifecycle SSM document

### DIFF
--- a/s3-lifecycle.tf
+++ b/s3-lifecycle.tf
@@ -2,7 +2,6 @@ resource "aws_ssm_document" "s3_lifecycle" {
   name            = "ConfigureS3BucketLifecycleRule"
   document_type   = "Automation"
   document_format = "YAML"
-  version_name    = "2.0.11"
 
   content = templatefile("${path.module}/automations/ConfigureS3BucketLifecycleRule.yaml", {})
 


### PR DESCRIPTION
## What

Remove the static `version_name = "2.0.11"` from the `aws_ssm_document.s3_lifecycle` resource.

## Why

Discovered while running the pre-upgrade `plan-all` baseline (ND-14966): the `config` module showed a perpetual, non-converging in-place diff — `+ version_name = "2.0.11"` across all 17 active `aws_config*` instances, every plan/apply, with document content unchanged.

Root cause: `version_name` is unique per SSM document version and can only be applied when the document **content** changes (a new version is created). A fixed value with unchanged content can never be recorded by AWS, so the provider reads it back as empty on every refresh and re-plans the add — forever.

- The python runtime bump this document needed was already delivered via a **content** change (`1c0c8f4`), not via `version_name`. Content drives versioning on its own.
- `version_name` was added later as a standalone line (`9c3d12d`) with no content change — the source of the loop.
- Left static, it would also **collide** on the next content bump: version_name must be unique across versions and can't be reused.

Removing it converges the diff to zero (state already holds `null`) and unblocks future content/runtime bumps. Only `s3_lifecycle` carried this attribute; `s3_tags` is unaffected.

## Follow-up

Consumers in `fn_terraform` pin this module by tag. A new tag off `master` after merge is required before the pin can move.